### PR TITLE
Add Reglinterface.Gl.t to module declaration

### DIFF
--- a/packages/reglnative/src/opengl.re
+++ b/packages/reglnative/src/opengl.re
@@ -32,7 +32,7 @@ let create_window gl::(maj, min) => {
   )
 };
 
-let module Gl = {
+let module Gl : Reglinterface.Gl.t = {
   let target = "native";
   type contextT = Sdl.gl_context;
   module type WindowT = {

--- a/packages/reglweb/src/webgl.re
+++ b/packages/reglweb/src/webgl.re
@@ -38,7 +38,7 @@ external addToBody : 'canvas => unit = "document.body.appendChild" [@@bs.val];
 
 external getContext : 'canvas => string => 'context = "getContext" [@@bs.send];
 
-let module Gl = {
+let module Gl : Reglinterface.Gl.t = {
   let target = "web";
   type contextT;
   module type WindowT = {


### PR DESCRIPTION
I was getting a lot of warnings in merlin while trying to code using matchenv and regl.  Changing this locally made all my warnings/errors go away.

It's not necessary for reglexampleproject because the functorization has the same effect (telling the compiler each backend should satisfy reglinterface), but when you use the matchenv approach, you never tell the compiler that that module should satisfy the module type.