### PR TITLE
fix delta passed to displayFunc in web

### DIFF
--- a/packages/reglweb/src/webgl.re
+++ b/packages/reglweb/src/webgl.re
@@ -153,11 +153,12 @@ let module Gl : Reglinterface.Gl.t = {
           }
         )
     };
-    let rec tick () => {
-      displayFunc (Document.now ());
-      Document.requestAnimationFrame tick
+    let rec tick prev () => {
+      let now = Document.now ();
+      displayFunc (now -. prev);
+      Document.requestAnimationFrame (tick now)
     };
-    Document.requestAnimationFrame tick
+    Document.requestAnimationFrame (tick (Document.now ()))
   };
   type programT;
   type shaderT;


### PR DESCRIPTION
We were passing Date.now() to displayFunc instead of the delta since the last frame.